### PR TITLE
Kuma: Remove arch hardcode and kubeopenapi-jsonschema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,21 +17,13 @@ COPY build/ build/
 # Build
 RUN GOPROXY=https://proxy.golang.org,direct CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-kuma main.go
 
-FROM alpine:3.15 as jsonschema-util
-RUN apk add --no-cache curl
-WORKDIR /
-RUN curl -LO https://github.com/layer5io/kubeopenapi-jsonschema/releases/download/v0.1.0/kubeopenapi-jsonschema
-RUN chmod +x /kubeopenapi-jsonschema
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/nodejs:latest
 WORKDIR /
 ENV DISTRO="debian"
-ENV GOARCH="amd64"
 ENV SERVICE_ADDR="meshery-kuma"
 ENV MESHERY_SERVER="http://meshery:9081"
 COPY templates/ ./templates
 COPY --from=builder /build/meshery-kuma .
-COPY --from=jsonschema-util /kubeopenapi-jsonschema /root/.meshery/bin/kubeopenapi-jsonschema
 ENTRYPOINT ["/meshery-kuma"]


### PR DESCRIPTION
**Description**
Removes hardcoding to amd64 arch.
Removes deprecated kubeopenapi-jsonschema

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
